### PR TITLE
Added a way for the controller to allow for robot beeping

### DIFF
--- a/rsk/backend.py
+++ b/rsk/backend.py
@@ -99,6 +99,10 @@ class Backend():
     def setKey(self, team, key):
         self.robots.control.setKey(team, key)
 
+    @api.slot(str, bool)
+    def allowBeeping(self, team, allow):
+        self.robots.control.allowBeeping(team, allow)
+
     @api.slot()
     def identify(self):
         self.robots.identify()

--- a/rsk/client.py
+++ b/rsk/client.py
@@ -76,7 +76,7 @@ class ClientRobot(ClientTracked):
         return self.client.command(self.color, self.number, 'control', [dx, dy, dturn])
 
     def beep(self, frequency, duration):
-        return self.client.command(self.color, self.number, 'beep', [frequency, duration])
+        return self.client.command(self.color, self.number, 'beep', [int(frequency), int(duration)])
 
     def goto(self, target, wait=True):
         if wait:

--- a/rsk/client.py
+++ b/rsk/client.py
@@ -75,6 +75,9 @@ class ClientRobot(ClientTracked):
 
         return self.client.command(self.color, self.number, 'control', [dx, dy, dturn])
 
+    def beep(self, frequency, duration):
+        return self.client.command(self.color, self.number, 'beep', [frequency, duration])
+
     def goto(self, target, wait=True):
         if wait:
             while not self.goto(target, wait=False):

--- a/rsk/control.py
+++ b/rsk/control.py
@@ -15,11 +15,13 @@ class Control:
         self.teams = {
             "green": {
                 "allow_control": True,
+                "allow_beeping": True,
                 "key": "",
                 "packets": 0
             },
             "blue": {
                 "allow_control": True,
+                "allow_beeping": True,
                 "key": "",
                 "packets": 0
             }
@@ -52,6 +54,13 @@ class Control:
                                         self.robots.robots_by_marker[marker].control(
                                             float(command[1]), float(command[2]), float(command[3]))
                                         response = [True, 'ok']
+                                    elif command[0] == 'beep' and len(command) == 3:
+                                        if self.teams[team]['allow_beeping']:
+                                            self.robots.robots_by_marker[marker].beep(
+                                                float(command[1]), float(command[2]))
+                                            response = [True, 'ok']
+                                        else:
+                                            response[1] = 'Beeping is disabled for your team'
                                     else:
                                         response[1] = 'Unknown command'
                             else:
@@ -76,6 +85,9 @@ class Control:
 
     def allowControl(self, team, allow):
         self.teams[team]['allow_control'] = allow
+
+    def allowBeeping(self, team, allow):
+        self.teams[team]['allow_beeping'] = allow
 
     def emergency(self):
         self.allowControl('green', False)

--- a/rsk/control.py
+++ b/rsk/control.py
@@ -57,7 +57,7 @@ class Control:
                                     elif command[0] == 'beep' and len(command) == 3:
                                         if self.teams[team]['allow_beeping']:
                                             self.robots.robots_by_marker[marker].beep(
-                                                float(command[1]), float(command[2]))
+                                                int(command[1]), int(command[2]))
                                             response = [True, 'ok']
                                         else:
                                             response[1] = 'Beeping is disabled for your team'

--- a/rsk/static/js/control.js
+++ b/rsk/static/js/control.js
@@ -8,6 +8,9 @@ function control_initialize(backend) {
             $('.allow-'+team).change(function() {
                 backend.allowControl(team, $(this).is(':checked'));
             });
+            $('.allow-beep-'+team).change(function() {
+                backend.allowBeeping(team, $(this).is(':checked'));
+            });
 
             $('.key-'+team).change(function() {
                 backend.setKey(team, $(this).val());
@@ -29,6 +32,7 @@ function control_initialize(backend) {
             backend.getGame(function(game) {
                 for (let team of ['green', 'blue']) {
                     $('.allow-'+team).prop('checked', game[team]['allow_control']);
+                    $('.allow-beep-'+team).prop('clicked', game[team]['allow_beeping'])
                     $('.packets-'+team).text(game[team]['packets']+' packets');
                     if (!$('.key-'+team).is(':focus')) {
                         $('.key-'+team).val(game[team]['key']);

--- a/rsk/static/team.html
+++ b/rsk/static/team.html
@@ -12,6 +12,7 @@
     Allow control
     <input type="checkbox" class="allow-{team} form-check-input" />
   </label>
+  <br>
   <label>
     Allow beeping
     <input type="checkbox" class="allow-beep-{team} form-check-input" />

--- a/rsk/static/team.html
+++ b/rsk/static/team.html
@@ -12,6 +12,10 @@
     Allow control
     <input type="checkbox" class="allow-{team} form-check-input" />
   </label>
+  <label>
+    Allow beeping
+    <input type="checkbox" class="allow-beep-{team} form-check-input" />
+  </label>
   <div class="float-end d-flex">
     <i class="bi bi-key m-1"></i>
     <input type="password" class="key-{team} form-control" placeholder="(no key)" />


### PR DESCRIPTION
This isn't a *necessary* change, but a welcome one in my opinion.
When I've seen the capabilities of the robots' beepers, I thought it would be both funny and entertaining to try and make them beep.

This functionnality can be toggled on/off in the Controller Web UI, and is still restricted by the team key.

I haven't tested the changes yet, will do so in the coming week, tho since this is a relativly small project, this shouldn't break anything.